### PR TITLE
인라인 도서 리스트 렌더링에서 썸네일 사이즈 직접관리하는 부분 제거

### DIFF
--- a/src/app/components/ExpandableBookList.tsx
+++ b/src/app/components/ExpandableBookList.tsx
@@ -35,6 +35,7 @@ export const ExpandableBookList: React.FunctionComponent<ExpandableBookListProps
                 disableInlineOnPC={isExpanded}
                 renderAuthor={false}
                 lazyloadThumbnail={false}
+                bookThumbnailSize={isMobile ? 110 : 120}
               />
               {(!isMobile && !isExpanded) && (
                 <div className="ExpandableBookList_ExpandButton_Wrapper">

--- a/src/app/components/InlineHorizontalBookList.tsx
+++ b/src/app/components/InlineHorizontalBookList.tsx
@@ -23,7 +23,7 @@ interface Props {
   bookThumbnailSize?: ThumbnailSize;
 }
 
-export const InlineHorizontalBookList: React.SFC<Props & ReturnType<typeof mapDispatchToProps>> = (props) => {
+export const InlineHorizontalBookList: React.FunctionComponent<Props & ReturnType<typeof mapDispatchToProps>> = (props) => {
   const {
     pageTitleForTracking,
     uiPartTitleForTracking,

--- a/src/app/components/InlineHorizontalBookList.tsx
+++ b/src/app/components/InlineHorizontalBookList.tsx
@@ -10,6 +10,7 @@ import { Book } from 'app/services/book';
 import { Actions, DefaultTrackingParams } from 'app/services/tracking';
 import { getSectionStringForTracking } from 'app/services/tracking/utils';
 import { stringifyAuthors } from 'app/utils/utils';
+import { ThumbnailSize } from './BookThumbnail';
 
 interface Props {
   pageTitleForTracking?: string;
@@ -19,6 +20,7 @@ interface Props {
   disableInlineOnPC?: boolean;
   lazyloadThumbnail?: boolean;
   renderAuthor?: boolean;
+  bookThumbnailSize?: ThumbnailSize;
 }
 
 export const InlineHorizontalBookList: React.SFC<Props & ReturnType<typeof mapDispatchToProps>> = (props) => {
@@ -31,6 +33,7 @@ export const InlineHorizontalBookList: React.SFC<Props & ReturnType<typeof mapDi
     lazyloadThumbnail,
     trackClick,
     renderAuthor,
+    bookThumbnailSize = 120,
   } = props;
 
   const section = !!pageTitleForTracking ? getSectionStringForTracking(pageTitleForTracking, uiPartTitleForTracking, filterForTracking) : undefined;
@@ -48,53 +51,49 @@ export const InlineHorizontalBookList: React.SFC<Props & ReturnType<typeof mapDi
             index={idx}
             id={book.id}
           >
-            <MediaQuery maxWidth={840}>
-              {(isSmallerThumbnail) => (
-                <>
-                  <DTOBookThumbnail
-                    book={book}
-                    width={isSmallerThumbnail ? 110 : 120}
-                    linkUrl={`/book/${book.id}`}
-                    linkType="Link"
-                    onLinkClick={() => section && trackClick({
-                      section,
-                      index: idx,
-                      id: book.id,
-                    })}
-                    imageClassName="InlineHorizontalBookList_Thumbnail"
-                    lazyload={lazyloadThumbnail}
-                  />
-                  <Link
-                    to={`/book/${book.id}`}
-                    className="InlineHorizontalBookList_Link"
-                    onClick={() => section && trackClick({
-                      section,
-                      index: idx,
-                      id: book.id,
-                    })}
-                  >
+            <>
+              <DTOBookThumbnail
+                book={book}
+                width={bookThumbnailSize}
+                linkUrl={`/book/${book.id}`}
+                linkType="Link"
+                onLinkClick={() => section && trackClick({
+                  section,
+                  index: idx,
+                  id: book.id,
+                })}
+                imageClassName="InlineHorizontalBookList_Thumbnail"
+                lazyload={lazyloadThumbnail}
+              />
+              <Link
+                to={`/book/${book.id}`}
+                className="InlineHorizontalBookList_Link"
+                onClick={() => section && trackClick({
+                  section,
+                  index: idx,
+                  id: book.id,
+                })}
+              >
+                <span
+                  className="InlineHorizontalBookList_Title"
+                  style={{
+                    width: `${bookThumbnailSize}px`,
+                  }}
+                >
+                  {book.title.main}
+                </span>
+                {renderAuthor && (
                     <span
-                      className="InlineHorizontalBookList_Title"
+                      className="InlineHorizontalBookList_Author"
                       style={{
-                        width: `${isSmallerThumbnail ? 110 : 120}px`,
+                        width: `${bookThumbnailSize}px`,
                       }}
                     >
-                      {book.title.main}
+                      {stringifyAuthors(book.authors, 2)}
                     </span>
-                    {renderAuthor && (
-                        <span
-                          className="InlineHorizontalBookList_Author"
-                          style={{
-                            width: `${isSmallerThumbnail ? 110 : 120}px`,
-                          }}
-                        >
-                          {stringifyAuthors(book.authors, 2)}
-                        </span>
-                    )}
-                  </Link>
-                </>
-              )}
-            </MediaQuery>
+                )}
+              </Link>
+            </>
           </ConnectedTrackImpression>
         </li>
       ))}

--- a/src/app/scenes/BookDetail.tsx
+++ b/src/app/scenes/BookDetail.tsx
@@ -12,7 +12,7 @@ const Vibrant = require('node-vibrant');
 import { Palette as VibrantPalette } from 'node-vibrant/lib/color';
 
 import { Button, Icon } from '@ridi/rsg';
-import { ConnectedInlineHorizontalBookList, ConnectedPageHeader, HelmetWithTitle } from 'app/components';
+import { ConnectedPageHeader, HelmetWithTitle } from 'app/components';
 import { ExpandableBookList } from 'app/components/ExpandableBookList';
 import { Notice } from 'app/components/Notice';
 import { FetchStatusFlag } from 'app/constants';

--- a/src/app/services/home/components/HomeSection.tsx
+++ b/src/app/services/home/components/HomeSection.tsx
@@ -103,11 +103,16 @@ export class HomeSection extends React.Component<Props> {
     return (
       <section className="HomeSection">
         <SectionHeader title={title!} link={collectionToPath({ collectionId: id })} />
-        <ConnectedInlineHorizontalBookList
-          books={collectionBooks}
-          pageTitleForTracking="home"
-          uiPartTitleForTracking={id.toString()}
-        />
+        <MediaQuery maxWidth={840}>
+          {(isMobile) => (
+            <ConnectedInlineHorizontalBookList
+              books={collectionBooks}
+              pageTitleForTracking="home"
+              uiPartTitleForTracking={id.toString()}
+              bookThumbnailSize={isMobile ? 110 : 120}
+            />
+          )}
+        </MediaQuery>
       </section>
     );
   }

--- a/src/app/services/home/components/HomeSpotlightSection.tsx
+++ b/src/app/services/home/components/HomeSpotlightSection.tsx
@@ -68,7 +68,7 @@ export class HomeSpotlightSection extends React.Component<Props> {
                   pageTitleForTracking="home"
                   uiPartTitleForTracking={collectionId.toString()}
                   renderAuthor={true}
-                  bookThumbnailSize={140}
+                  bookThumbnailSize={110}
                 />
               ) : (
                 <div className="HomeSection_Spotlight_Slider">

--- a/src/app/services/home/components/HomeSpotlightSection.tsx
+++ b/src/app/services/home/components/HomeSpotlightSection.tsx
@@ -68,6 +68,7 @@ export class HomeSpotlightSection extends React.Component<Props> {
                   pageTitleForTracking="home"
                   uiPartTitleForTracking={collectionId.toString()}
                   renderAuthor={true}
+                  bookThumbnailSize={140}
                 />
               ) : (
                 <div className="HomeSection_Spotlight_Slider">


### PR DESCRIPTION
썸네일 사이즈는 사용처에따라 변경 가능성이 있기 때문에 외부에서 필요한 사이즈로 주입해서 사용하도록 수정.

인라인 도서 리스트 컴포넌트의 역할은 데이터와 사이즈를 받아서 렌더하는 부분까지만 하도록.