### PR TITLE
Article Instant Search 기능 추가 및 검색 api 호출 public API로 변경

### DIFF
--- a/src/app/components/GNB.tsx
+++ b/src/app/components/GNB.tsx
@@ -30,6 +30,7 @@ interface Props {
   BASE_URL_RIDISELECT: string;
   LIBRARY_URL: string;
   isFetching: boolean;
+  isGnbTab: boolean;
   isInApp: boolean;
   isIosInApp: boolean;
   isAndroidInApp: boolean;
@@ -53,7 +54,7 @@ const GNBTabMenus: GNBTab[] = [
   },
   {
     name: '아티클',
-    classname: 'Article',
+    classname: 'Articles',
     pathname: RoutePaths.ARTICLE_HOME,
   },
 ];

--- a/src/app/components/InstantSearch.tsx
+++ b/src/app/components/InstantSearch.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { InstantSearchResultArticle, InstantSearchResultBook } from 'app/components/Search';
 import { FetchStatusFlag } from 'app/constants';
 import { getAuthorsCount, getSortedAuthorsHtmlString } from 'app/utils/search';
+import { articleContentToPath } from 'app/utils/toPath';
 
 interface InstantSearchProps {
   keyword: string;
@@ -79,7 +80,7 @@ export class InstantSearch extends React.PureComponent<InstantSearchProps> {
                 >
                   <Link
                     className="InstantSearchedName"
-                    to={`/article/@${article.channelDisplayName}/${article.title}?q=${encodeURIComponent(keyword)}&s=instant`}
+                    to={`${articleContentToPath({channelName: article.channelName, contentId: article.contentId})}?q=${encodeURIComponent(keyword)}&s=instant`}
                   >
                     <span
                       className="InstantSearchTitle"

--- a/src/app/components/InstantSearch.tsx
+++ b/src/app/components/InstantSearch.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
-import { InstantSearchResultBook } from 'app/components/Search';
+import { InstantSearchResultArticle, InstantSearchResultBook } from 'app/components/Search';
 import { FetchStatusFlag } from 'app/constants';
 import { getAuthorsCount, getSortedAuthorsHtmlString } from 'app/utils/search';
 
@@ -9,10 +9,11 @@ interface InstantSearchProps {
   keyword: string;
   isActive: boolean;
   fetchStatus: FetchStatusFlag;
-  instantSearchList: InstantSearchResultBook[];
+  searchType: string;
+  instantSearchList: InstantSearchResultBook[] | InstantSearchResultArticle[];
   highlightIndex: number;
   updateHighlight: (idx: number) => void;
-  onSearchItemClick: (book: InstantSearchResultBook) => void;
+  onSearchItemClick: (item: InstantSearchResultBook | InstantSearchResultArticle) => void;
 }
 
 export class InstantSearch extends React.PureComponent<InstantSearchProps> {
@@ -21,6 +22,7 @@ export class InstantSearch extends React.PureComponent<InstantSearchProps> {
       keyword,
       isActive,
       fetchStatus,
+      searchType,
       instantSearchList,
       highlightIndex,
       updateHighlight,
@@ -38,7 +40,8 @@ export class InstantSearch extends React.PureComponent<InstantSearchProps> {
       <div className="InstantSearchWrapper">
         {fetchStatus === FetchStatusFlag.FETCHING ? null : (
           <ul className="InstantSearchList">
-            {instantSearchList ? instantSearchList.map((book, idx) => (
+            {instantSearchList ? (
+              searchType === 'Books' ? (instantSearchList as InstantSearchResultBook[]).map((book, idx) => (
                 <li
                   className={`InstantSearchItem${highlightIndex === idx ? ' focused' : ''}`}
                   onMouseOver={() => updateHighlight(idx)}
@@ -47,27 +50,52 @@ export class InstantSearch extends React.PureComponent<InstantSearchProps> {
                 >
                   <Link
                     className="InstantSearchedName"
-                    to={`/book/${book.id}?q=${encodeURIComponent(keyword)}&s=instant`}
+                    to={`/book/${book.bId}?q=${encodeURIComponent(keyword)}&s=instant`}
                   >
                     <span
                       className="InstantSearchTitle"
-                      dangerouslySetInnerHTML={{__html: book.highlightTitle ? book.highlightTitle : book.title}}
+                      dangerouslySetInnerHTML={{__html: book.highlight.webTitleTitle ? book.highlight.webTitleTitle : book.title}}
                     />
                     <span
                       className="InstantSearchAuthor"
                       dangerouslySetInnerHTML={{__html: getSortedAuthorsHtmlString(
-                        book.highlightAuthor ? book.highlightAuthor : book.author,
+                        book.highlight.author ? book.highlight.author : book.author,
                         getAuthorsCount(book.author),
                         2,
                       )}}
                     />
                     <span
                       className="InstantSearchPublisher"
-                      dangerouslySetInnerHTML={{__html: book.highlightPublisher ? book.highlightPublisher : book.publisher}}
+                      dangerouslySetInnerHTML={{__html: book.highlight.publisher ? book.highlight.publisher : book.publisher}}
                     />
                   </Link>
                 </li>
-              )) : null
+              )) : (instantSearchList as InstantSearchResultArticle[]).map((article, idx) => (
+                <li
+                  className={`InstantSearchItem${highlightIndex === idx ? ' focused' : ''}`}
+                  onMouseOver={() => updateHighlight(idx)}
+                  key={`instant_search_${idx}`}
+                  onClick={() => onSearchItemClick(article)}
+                >
+                  <Link
+                    className="InstantSearchedName"
+                    to={`/article/@${article.channelDisplayName}/${article.title}?q=${encodeURIComponent(keyword)}&s=instant`}
+                  >
+                    <span
+                      className="InstantSearchTitle"
+                      dangerouslySetInnerHTML={{__html: article.highlight.title ? article.highlight.title : article.title}}
+                    />
+                    <span
+                      className="InstantSearchAuthor"
+                      dangerouslySetInnerHTML={{__html: getSortedAuthorsHtmlString(
+                        article.highlight.channelDisplayName ? article.highlight.channelDisplayName : article.channelDisplayName,
+                        getAuthorsCount(article.channelDisplayName),
+                        2,
+                      )}}
+                    />
+                  </Link>
+                </li>
+              ))) : null
             }
           </ul>
         )}

--- a/src/app/components/Search.tsx
+++ b/src/app/components/Search.tsx
@@ -25,6 +25,7 @@ import toast from 'app/utils/toast';
 import { setDisableScroll } from 'app/utils/utils';
 
 import env from 'app/config/env';
+import { articleContentToPath } from 'app/utils/toPath';
 
 export enum SearchHelperFlag {
   NONE,
@@ -54,6 +55,8 @@ export interface InstantSearchResultArticle {
   id: number;
   channelId: number;
   channelDisplayName: string;
+  channelName: string;
+  contentId: number;
   title: string;
   highlight: InstantSearchArticleHighlight;
 }
@@ -376,7 +379,7 @@ export class Search extends React.Component<SearchProps, SearchState> {
     this.setStateClean();
     this.pushHistoryKeyword(targetKeyword);
 
-    history.push(`/article/@${article.channelDisplayName}/${article.title}?q=${encodeURIComponent(targetKeyword)}&s=instant`);
+    history.push(`${articleContentToPath({channelName: article.channelName, contentId: article.contentId})}?q=${encodeURIComponent(targetKeyword)}&s=instant`);
   }
 
   private fullSearchWithKeyword(keyword: string): void {

--- a/src/app/config/env.ts
+++ b/src/app/config/env.ts
@@ -14,6 +14,7 @@ export default {
   PAY_URL: getEnv('PAY_URL', process.env.PAY_URL) || 'https://pay.ridibooks.com',
   PAY_API: getEnv('PAY_API', process.env.PAY_API) || 'https://pay-api.ridibooks.com',
   ACCOUNT_API: getEnv('ACCOUNT_API', process.env.ACCOUNT_API) || 'https://account.ridibooks.com',
+  SEARCH_API: getEnv('SEARCH_API', process.env.SEARCH_API) || 'https://search-api.ridibooks.com',
   OAUTH2_CLIENT_ID: process.env.OAUTH2_CLIENT_ID || '',
   FREE_PROMOTION_MONTHS: Number(process.env.FREE_PROMOTION_MONTHS) || 1,
 

--- a/src/app/constants/index.ts
+++ b/src/app/constants/index.ts
@@ -70,5 +70,9 @@ export enum RoutePaths {
   ARTICLE_CHANNELS = '/article/channels',
   ARTICLE_CHANNEL_DETAIL = '/article/channel/:channelId',
   ARTICLE_FAVORITE = '/article/favorite',
+<<<<<<< HEAD
   ARTICLE_CONTENT = '/article/@:channelName/:contentIndex',
+=======
+  ARTICLE_CONTENT = '/article/@:channelName/:contentId',
+>>>>>>> article content url 변경
 }

--- a/src/app/constants/index.ts
+++ b/src/app/constants/index.ts
@@ -70,9 +70,5 @@ export enum RoutePaths {
   ARTICLE_CHANNELS = '/article/channels',
   ARTICLE_CHANNEL_DETAIL = '/article/channel/:channelId',
   ARTICLE_FAVORITE = '/article/favorite',
-<<<<<<< HEAD
   ARTICLE_CONTENT = '/article/@:channelName/:contentIndex',
-=======
-  ARTICLE_CONTENT = '/article/@:channelName/:contentId',
->>>>>>> article content url 변경
 }

--- a/src/app/hocs/AppManager.tsx
+++ b/src/app/hocs/AppManager.tsx
@@ -31,8 +31,8 @@ export class AppManager extends React.Component<Props> {
   private updateAppStatus = () => {
     const { location, appStatus, dispatchUpdateAppStatus } = this.props;
     if (appStatus === AppStatus.Books && location.pathname.indexOf('/article/') >= 0) {
-      dispatchUpdateAppStatus(AppStatus.Article);
-    } else if (appStatus === AppStatus.Article && location.pathname.indexOf('/article/') < 0) {
+      dispatchUpdateAppStatus(AppStatus.Articles);
+    } else if (appStatus === AppStatus.Articles && location.pathname.indexOf('/article/') < 0) {
       dispatchUpdateAppStatus(AppStatus.Books);
     }
   }

--- a/src/app/services/app/index.ts
+++ b/src/app/services/app/index.ts
@@ -8,7 +8,7 @@ export const Actions = {
 
 export enum AppStatus {
   Books = 'Books',
-  Article = 'Article',
+  Article = 'Articles',
 }
 
 export interface AppState {

--- a/src/app/services/app/index.ts
+++ b/src/app/services/app/index.ts
@@ -8,7 +8,7 @@ export const Actions = {
 
 export enum AppStatus {
   Books = 'Books',
-  Article = 'Articles',
+  Articles = 'Articles',
 }
 
 export interface AppState {

--- a/src/app/services/searchResult/requests.ts
+++ b/src/app/services/searchResult/requests.ts
@@ -1,7 +1,6 @@
 import { camelize } from '@ridi/object-case-converter';
 import request from 'app/config/axios';
-import env from 'app/config/env';
-import { SearchResultBook } from 'app/services/searchResult/reducer.state';
+import { SearchResultBook } from 'app/services/searchResult';
 import { AxiosResponse } from 'axios';
 
 export interface SearchResultReponse {

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,5 +1,4 @@
 import { connectRouter, routerMiddleware, RouterState } from 'connected-react-router';
-import { History } from 'history';
 import { isEmpty } from 'lodash-es';
 import * as qs from 'qs';
 import { Dispatch } from 'redux';

--- a/src/app/utils/search.ts
+++ b/src/app/utils/search.ts
@@ -4,6 +4,7 @@ export interface SearchLocalStorageData {
   history: {
     enabled: boolean;
     keywordList: string[];
+    articleKeywordList: string[];
   };
 }
 
@@ -17,6 +18,7 @@ export const localStorageManager = (() => ({
     const parsedLocalStorageData = localStorageData === '' ? {
       enabled: true,
       keywordList: [],
+      articleKeywordList: [],
     } : JSON.parse(localStorageData).history;
     const parseData: SearchLocalStorageData = {
       history: {
@@ -24,6 +26,7 @@ export const localStorageManager = (() => ({
           parsedLocalStorageData.enabled :
           true,
         keywordList: parsedLocalStorageData.keywordList ? parsedLocalStorageData.keywordList : [],
+        articleKeywordList: parsedLocalStorageData.articleKeywordList ? parsedLocalStorageData.articleKeywordList : [],
       },
     };
     return {
@@ -35,6 +38,7 @@ export const localStorageManager = (() => ({
     newData.history = {
       enabled: state.history.enabled,
       keywordList: state.history.keywordList,
+      articleKeywordList: state.history.articleKeywordList,
     };
     try {
       localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newData));

--- a/src/app/utils/search.ts
+++ b/src/app/utils/search.ts
@@ -3,7 +3,7 @@ const LOCAL_STORAGE_KEY = 'rs.search';
 export interface SearchLocalStorageData {
   history: {
     enabled: boolean;
-    keywordList: string[];
+    bookKeywordList: string[];
     articleKeywordList: string[];
   };
 }
@@ -17,7 +17,7 @@ export const localStorageManager = (() => ({
     const localStorageData = localStorage.getItem(LOCAL_STORAGE_KEY) || '';
     const parsedLocalStorageData = localStorageData === '' ? {
       enabled: true,
-      keywordList: [],
+      bookKeywordList: [],
       articleKeywordList: [],
     } : JSON.parse(localStorageData).history;
     const parseData: SearchLocalStorageData = {
@@ -25,7 +25,7 @@ export const localStorageManager = (() => ({
         enabled: (parsedLocalStorageData.enabled !== undefined) && (parsedLocalStorageData.enabled !== null) ?
           parsedLocalStorageData.enabled :
           true,
-        keywordList: parsedLocalStorageData.keywordList ? parsedLocalStorageData.keywordList : [],
+          bookKeywordList: parsedLocalStorageData.bookKeywordList ? parsedLocalStorageData.bookKeywordList : [],
         articleKeywordList: parsedLocalStorageData.articleKeywordList ? parsedLocalStorageData.articleKeywordList : [],
       },
     };
@@ -37,7 +37,7 @@ export const localStorageManager = (() => ({
     const newData: SearchLocalStorageData = localStorageManager.load();
     newData.history = {
       enabled: state.history.enabled,
-      keywordList: state.history.keywordList,
+      bookKeywordList: state.history.bookKeywordList,
       articleKeywordList: state.history.articleKeywordList,
     };
     try {


### PR DESCRIPTION
GNB쪽의 instant search에 아티클타입을 추가했습니다.
아티클 url 주소 결정하는 부분이 아직 필요한 response값이 없어서 임시로 해두고 추후 추가되면 수정할 것 같아요 
기존 instant search 부분이 rxjs로 작성되어 있어 최대한 손대지 않고 추가했는데
나중에 rx를 걷어내던지 해야 할 것 같습니다. ㅠㅠ

또, 기존 사용하던 api 대신 public으로 변경된 search api를 직접 가져오도록 변경했습니다.
