### PR TITLE
Use docker-compose without build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM node:12-alpine
-WORKDIR /app
-
-COPY package.json yarn.lock ./
-
-RUN yarn install --frozen-lockfile
-CMD yarn start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,25 @@
-version: "3.6"
+version: "3.7"
 
 services:
   web:
-    image: ridiselect/web
-    build: .
+    image: node:12-alpine
+    container_name: select
+    working_dir: /app
     ports:
       - 9000
+    init: true
     labels:
       - "traefik.enable=true"
       - "traefik.frontend.rule=Host:select.local.ridi.io"
     volumes:
       - .:/app
-      - /app/node_modules
+      - node_modules:/app/node_modules
+    command: >
+      sh -c "yarn install --frozen-lockfile &&
+             yarn start"
+
+volumes:
+  node_modules:
 
 networks:
   default:


### PR DESCRIPTION
도커 이미지를 빌드하지 않고 node_modules 디렉토리는 named volume 으로 사용합니다.
 
- 컨테이너를 올릴때마다 약 1초 정도의 시간이 추가로 소요되지만 패키지 업데이트를 관리할 필요가 없습니다.
- `docker-compose down -v` 명령어를 사용하면 `node_modules` volume이 삭제됩니다.