### PR TITLE
아티클 페이지 비구독자 베너버튼 하단 고정 시 사이즈 이슈 대응

### DIFF
--- a/src/css/articleContent/index.css
+++ b/src/css/articleContent/index.css
@@ -100,7 +100,7 @@
 
   &.ArticleContent_GetTicketToReadButtonWrapper-publicContent {
     &.ArticleContent_GetTicketToReadButtonWrapper-sticky {
-      padding: 10px 20px;
+      padding: 10px 0;
       height: auto;
       background: none;
     }


### PR DESCRIPTION
하단 고정되며 가로폭이 변하는 [이슈](https://app.asana.com/0/760729968221377/1156748734527281) 대응 건 입니다.
