### PR TITLE
article admin 에 대응하여 여백 스타일 수정

### DIFF
--- a/src/css/articleContentStyle.css
+++ b/src/css/articleContentStyle.css
@@ -323,7 +323,7 @@
     }
     & hr {
       &::before {
-        width: calc(100vw - 40px);
+        width: calc(100% - 40px);
       }
     }
     & iframe {


### PR DESCRIPTION
- admin 은 web 과 달리 컨텐츠가 레이어링 되어있어 vw 유닛을 사용하면 에디터에서 스타일을 정확하게 확인할 수 없음
- web은 그대로 두어도 상관 없지만 CSS 통일성을 위해 수정 