### PR TITLE
웹폰트 호출부 수정 및 누락된 웹폰트 추가

### DIFF
--- a/src/css/font.css
+++ b/src/css/font.css
@@ -1,1 +1,48 @@
 @import url('https://fonts.googleapis.com/css?family=Noto+Sans+KR:500&display=swap&subset=korean');
+
+@font-face {
+  font-family: Noto Sans KR;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(../fonts/NotoSans-Regular.woff2) format('woff2'),
+    url(../fonts/NotoSans-Regular.woff) format('woff'),
+    url(../fonts/NotoSans-Regular.otf) format('opentype');
+}
+
+@font-face {
+  font-family: Noto Sans KR;
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(../fonts/NotoSans-Bold.woff2) format('woff2'),
+    url(../fonts/NotoSans-Bold.woff) format('woff'),
+    url(../fonts/NotoSans-Bold.otf) format('opentype');
+}
+
+@font-face {
+  font-family: Noto Sans KR;
+  font-style: normal;
+  font-weight: 900;
+  font-display: swap;
+  src: url(../fonts/NotoSans-Black.woff2) format('woff2'),
+    url(../fonts/NotoSans-Black.woff) format('woff'),
+    url(../fonts/NotoSans-Black.otf) format('opentype');
+}
+
+@font-face {
+  font-family: Minion Pro;
+  font-style: normal;
+  font-display: swap;
+  src: url(../fonts/best_num.woff2) format('woff2'), url(../fonts/best_num.woff) format('woff'),
+    url(../fonts/best_num.ttf) format('truetype');
+}
+
+@font-face {
+  font-family: review_num;
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(../fonts/review_num.woff2) format('woff2'), url(../fonts/review_num.woff) format('woff'),
+    url(../fonts/review_num.ttf) format('truetype');
+}


### PR DESCRIPTION
지난 PR 에 minion pro 와 review 가 빠져있었네요.
기존 noto sans 를 원복하고 font-display: swap 을 추가 했습니다.