### PR TITLE
Fix/react responsive

### DIFF
--- a/src/app/ResponsiveManager.tsx
+++ b/src/app/ResponsiveManager.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { useMediaQuery } from 'react-responsive';
+
+import { MAX_WIDTH } from 'app/constants';
+import { Actions as CommonUIActions } from 'app/services/commonUI';
+
+const ResponsiveManager: React.FunctionComponent = () => {
+  const dispatch = useDispatch();
+  const isMobile = useMediaQuery({ maxWidth: MAX_WIDTH });
+  React.useEffect(() => {
+    dispatch(CommonUIActions.updateIsMobile({ isMobile }));
+  }, [isMobile]);
+  return null;
+};
+
+export default ResponsiveManager;

--- a/src/app/components/Home/HomeChartBooksSection.tsx
+++ b/src/app/components/Home/HomeChartBooksSection.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { ConnectedTrackImpression } from 'app/components/TrackImpression';
 import { Actions, DefaultTrackingParams } from 'app/services/tracking';
 
 import { DTOBookThumbnail } from 'app/components';
-import { MAX_WIDTH, CoverSizes } from 'app/constants';
+import { CoverSizes } from 'app/constants';
 import { Book } from 'app/services/book';
 import { CollectionId, ReservedCollectionIds } from 'app/services/collection';
+import { getIsMobile } from 'app/services/commonUI/selectors';
 import { groupChartBooks } from 'app/services/home/uitls';
 import { StarRating } from 'app/services/review';
 import { getSectionStringForTracking } from 'app/services/tracking/utils';
 import { thousandsSeperator } from 'app/utils/thousandsSeperator';
-import MediaQuery from 'react-responsive';
 import { Link } from 'react-router-dom';
 import { SectionHeader } from './HomeSection';
 
@@ -23,11 +23,17 @@ interface HomeChartBooksSectionProps {
   order?: number;
 }
 
-type Props = HomeChartBooksSectionProps & ReturnType<typeof mapDispatchToProps>;
+export const ConnectedHomeChartBooksSection: React.FunctionComponent<HomeChartBooksSectionProps> = props => {
+  const { books, order, title } = props;
+  const isMobile = useSelector(getIsMobile);
+  const dispatch = useDispatch();
 
-export class HomeChartBooksSection extends React.Component<Props> {
-  public renderCharts(contentsCount: number) {
-    const { books, trackClick, order } = this.props;
+  const trackClick = (trackingParams: DefaultTrackingParams) => {
+    dispatch(Actions.trackClick({ trackingParams }));
+  };
+
+  const renderCharts = () => {
+    const contentsCount = isMobile ? 24 : 12;
     const section = getSectionStringForTracking(
       'select-book',
       'home',
@@ -98,28 +104,12 @@ export class HomeChartBooksSection extends React.Component<Props> {
           ))}
       </div>
     );
-  }
+  };
 
-  public render() {
-    const { title } = this.props;
-
-    return (
-      <div className="HomeSection HomeSection-horizontal-pad">
-        <SectionHeader title={title || '인기 도서'} link="/charts" />
-        <MediaQuery maxWidth={MAX_WIDTH}>
-          {isMobile => (isMobile ? this.renderCharts(24) : this.renderCharts(12))}
-        </MediaQuery>
-      </div>
-    );
-  }
-}
-
-const mapDispatchToProps = (dispatch: any) => ({
-  trackClick: (trackingParams: DefaultTrackingParams) =>
-    dispatch(Actions.trackClick({ trackingParams })),
-});
-
-export const ConnectedHomeChartBooksSection = connect(
-  null,
-  mapDispatchToProps,
-)(HomeChartBooksSection);
+  return (
+    <div className="HomeSection HomeSection-horizontal-pad">
+      <SectionHeader title={title || '인기 도서'} link="/charts" isMobile={isMobile} />
+      {renderCharts()}
+    </div>
+  );
+};

--- a/src/app/components/Home/HomeSection.tsx
+++ b/src/app/components/Home/HomeSection.tsx
@@ -25,29 +25,32 @@ interface HomeSectionProps {
   order?: number;
 }
 
-export const SectionHeader: React.SFC<{ title: string; link: string }> = props => {
-  const isMobile = useSelector(getIsMobile);
-  return (
-    <div className="HomeSection_Header">
-      {isMobile ? (
-        <Link to={props.link}>
-          <h2 className="HomeSection_Title reset-heading">
-            {props.title}
-            <Icon name="arrow_5_right" className="HomeSection_TitleArrowIcon" />
-          </h2>
+interface SectionHeaderProps {
+  title: string;
+  link: string;
+  isMobile: boolean;
+}
+
+export const SectionHeader: React.SFC<SectionHeaderProps> = props => (
+  <div className="HomeSection_Header">
+    {props.isMobile ? (
+      <Link to={props.link}>
+        <h2 className="HomeSection_Title reset-heading">
+          {props.title}
+          <Icon name="arrow_5_right" className="HomeSection_TitleArrowIcon" />
+        </h2>
+      </Link>
+    ) : (
+      <div className="HomeSection_Title">
+        <h2 className="reset-heading">{props.title}</h2>
+        <Link to={props.link} className="HomeSection_TitleLink">
+          전체 보기
+          <Icon name="arrow_5_right" className="HomeSection_TitleArrowIcon" />
         </Link>
-      ) : (
-        <div className="HomeSection_Title">
-          <h2 className="reset-heading">{props.title}</h2>
-          <Link to={props.link} className="HomeSection_TitleLink">
-            전체 보기
-            <Icon name="arrow_5_right" className="HomeSection_TitleArrowIcon" />
-          </Link>
-        </div>
-      )}
-    </div>
-  );
-};
+      </div>
+    )}
+  </div>
+);
 
 export const ConnectedHomeSection: React.FunctionComponent<HomeSectionProps> = props => {
   const isMobile = useSelector(getIsMobile);
@@ -94,7 +97,11 @@ export const ConnectedHomeSection: React.FunctionComponent<HomeSectionProps> = p
 
   return (
     <section className="HomeSection">
-      <SectionHeader title={title || ''} link={collectionToPath({ collectionId: id })} />
+      <SectionHeader
+        title={title || ''}
+        link={collectionToPath({ collectionId: id })}
+        isMobile={isMobile}
+      />
       <ConnectedInlineHorizontalBookList
         books={collectionBooks}
         serviceTitleForTracking="select-book"

--- a/src/app/components/Home/HomeSection.tsx
+++ b/src/app/components/Home/HomeSection.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useMediaQuery } from 'react-responsive';
 import { Link } from 'react-router-dom';
 
 import { Icon } from '@ridi/rsg';
 import { ConnectedInlineHorizontalBookList } from 'app/components/InlineHorizontalBookList';
-import { MAX_WIDTH, FetchStatusFlag } from 'app/constants';
+import { FetchStatusFlag } from 'app/constants';
 
 import { HomeSectionPlaceholder } from 'app/placeholder/HomeSectionPlaceholder';
 import { Book } from 'app/services/book';
@@ -14,6 +13,7 @@ import {
   SpotlightCollectionState,
   CollectionType,
 } from 'app/services/collection';
+import { getIsMobile } from 'app/services/commonUI/selectors';
 import { RidiSelectState } from 'app/store';
 import { collectionToPath } from 'app/utils/toPath';
 import { ConnectedHomeChartBooksSection } from './HomeChartBooksSection';
@@ -26,7 +26,7 @@ interface HomeSectionProps {
 }
 
 export const SectionHeader: React.SFC<{ title: string; link: string }> = props => {
-  const isMobile = useMediaQuery({ maxWidth: MAX_WIDTH });
+  const isMobile = useSelector(getIsMobile);
   return (
     <div className="HomeSection_Header">
       {isMobile ? (
@@ -50,7 +50,7 @@ export const SectionHeader: React.SFC<{ title: string; link: string }> = props =
 };
 
 export const ConnectedHomeSection: React.FunctionComponent<HomeSectionProps> = props => {
-  const isMobile = useMediaQuery({ maxWidth: MAX_WIDTH });
+  const isMobile = useSelector(getIsMobile);
   const books = useSelector((state: RidiSelectState) => state.booksById);
   const { collection, onScreen, order } = props;
   const { type, title, id, itemListByPage } = collection;

--- a/src/app/components/Home/HomeSection.tsx
+++ b/src/app/components/Home/HomeSection.tsx
@@ -75,7 +75,7 @@ export const ConnectedHomeSection: React.FunctionComponent<HomeSectionProps> = p
     return (
       <ConnectedHomeSpotlightSection
         books={collectionBooks}
-        title={title!}
+        title={title}
         collectionId={collection.id}
       />
     );

--- a/src/app/components/Home/HomeSection.tsx
+++ b/src/app/components/Home/HomeSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import MediaQuery from 'react-responsive';
+import { useSelector } from 'react-redux';
+import { useMediaQuery } from 'react-responsive';
 import { Link } from 'react-router-dom';
 
 import { Icon } from '@ridi/rsg';
@@ -8,7 +8,7 @@ import { ConnectedInlineHorizontalBookList } from 'app/components/InlineHorizont
 import { MAX_WIDTH, FetchStatusFlag } from 'app/constants';
 
 import { HomeSectionPlaceholder } from 'app/placeholder/HomeSectionPlaceholder';
-import { Book, BookState } from 'app/services/book';
+import { Book } from 'app/services/book';
 import {
   DefaultCollectionState,
   SpotlightCollectionState,
@@ -25,101 +25,84 @@ interface HomeSectionProps {
   order?: number;
 }
 
-interface HomeCollectionStateProps {
-  books: BookState;
-}
-
-type Props = HomeSectionProps & HomeCollectionStateProps;
-
-export const SectionHeader: React.SFC<{ title: string; link: string }> = props => (
-  <div className="HomeSection_Header">
-    <MediaQuery maxWidth={MAX_WIDTH}>
-      {isMobile =>
-        isMobile ? (
-          <Link to={props.link}>
-            <h2 className="HomeSection_Title reset-heading">
-              {props.title}
-              <Icon name="arrow_5_right" className="HomeSection_TitleArrowIcon" />
-            </h2>
+export const SectionHeader: React.SFC<{ title: string; link: string }> = props => {
+  const isMobile = useMediaQuery({ maxWidth: MAX_WIDTH });
+  return (
+    <div className="HomeSection_Header">
+      {isMobile ? (
+        <Link to={props.link}>
+          <h2 className="HomeSection_Title reset-heading">
+            {props.title}
+            <Icon name="arrow_5_right" className="HomeSection_TitleArrowIcon" />
+          </h2>
+        </Link>
+      ) : (
+        <div className="HomeSection_Title">
+          <h2 className="reset-heading">{props.title}</h2>
+          <Link to={props.link} className="HomeSection_TitleLink">
+            전체 보기
+            <Icon name="arrow_5_right" className="HomeSection_TitleArrowIcon" />
           </Link>
-        ) : (
-          <div className="HomeSection_Title">
-            <h2 className="reset-heading">{props.title}</h2>
-            <Link to={props.link} className="HomeSection_TitleLink">
-              전체 보기
-              <Icon name="arrow_5_right" className="HomeSection_TitleArrowIcon" />
-            </Link>
-          </div>
-        )
-      }
-    </MediaQuery>
-  </div>
-);
+        </div>
+      )}
+    </div>
+  );
+};
 
-export class HomeSection extends React.Component<Props> {
-  public render() {
-    const { collection, onScreen, books, order } = this.props;
-    const { type, title, id, itemListByPage } = collection;
-    const collectionBooks: Book[] = itemListByPage[1]?.itemList?.map(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      (bookId: number) => books[bookId]?.book!,
-    );
+export const ConnectedHomeSection: React.FunctionComponent<HomeSectionProps> = props => {
+  const isMobile = useMediaQuery({ maxWidth: MAX_WIDTH });
+  const books = useSelector((state: RidiSelectState) => state.booksById);
+  const { collection, onScreen, order } = props;
+  const { type, title, id, itemListByPage } = collection;
+  const collectionBooks: Book[] = itemListByPage[1]?.itemList?.map(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    (bookId: number) => books[bookId]?.book!,
+  );
 
-    if (
-      (itemListByPage[1].fetchStatus === FetchStatusFlag.IDLE &&
-        itemListByPage[1].itemList.length < 1) ||
-      itemListByPage[1].fetchStatus === FetchStatusFlag.FETCH_ERROR
-    ) {
-      return null;
-    }
+  if (
+    (itemListByPage[1].fetchStatus === FetchStatusFlag.IDLE &&
+      itemListByPage[1].itemList.length < 1) ||
+    itemListByPage[1].fetchStatus === FetchStatusFlag.FETCH_ERROR
+  ) {
+    return null;
+  }
 
-    if (!onScreen || itemListByPage[1].fetchStatus === FetchStatusFlag.FETCHING) {
-      return <HomeSectionPlaceholder type={collection.type} key={`${collection.id}_skeleton`} />;
-    }
+  if (!onScreen || itemListByPage[1].fetchStatus === FetchStatusFlag.FETCHING) {
+    return <HomeSectionPlaceholder type={collection.type} key={`${collection.id}_skeleton`} />;
+  }
 
-    if (type === CollectionType.SPOTLIGHT) {
-      return (
-        <ConnectedHomeSpotlightSection
-          books={collectionBooks}
-          title={title}
-          collectionId={collection.id}
-        />
-      );
-    }
-
-    if (type === CollectionType.CHART) {
-      return (
-        <ConnectedHomeChartBooksSection
-          books={collectionBooks}
-          title={title}
-          collectionId={id}
-          order={order}
-        />
-      );
-    }
-
+  if (type === CollectionType.SPOTLIGHT) {
     return (
-      <section className="HomeSection">
-        <SectionHeader title={title || ''} link={collectionToPath({ collectionId: id })} />
-        <MediaQuery maxWidth={MAX_WIDTH}>
-          {isMobile => (
-            <ConnectedInlineHorizontalBookList
-              books={collectionBooks}
-              serviceTitleForTracking="select-book"
-              pageTitleForTracking="home"
-              uiPartTitleForTracking="collection-list"
-              miscTracking={JSON.stringify({ sect_collection_id: id, sect_order: order })}
-              bookThumbnailSize={isMobile ? 110 : 120}
-            />
-          )}
-        </MediaQuery>
-      </section>
+      <ConnectedHomeSpotlightSection
+        books={collectionBooks}
+        title={title!}
+        collectionId={collection.id}
+      />
     );
   }
-}
 
-const mapStateToProps = (state: RidiSelectState): HomeCollectionStateProps => ({
-  books: state.booksById,
-});
+  if (type === CollectionType.CHART) {
+    return (
+      <ConnectedHomeChartBooksSection
+        books={collectionBooks}
+        title={title}
+        collectionId={id}
+        order={order}
+      />
+    );
+  }
 
-export const ConnectedHomeSection = connect(mapStateToProps, {})(HomeSection);
+  return (
+    <section className="HomeSection">
+      <SectionHeader title={title || ''} link={collectionToPath({ collectionId: id })} />
+      <ConnectedInlineHorizontalBookList
+        books={collectionBooks}
+        serviceTitleForTracking="select-book"
+        pageTitleForTracking="home"
+        uiPartTitleForTracking="collection-list"
+        miscTracking={JSON.stringify({ sect_collection_id: id, sect_order: order })}
+        bookThumbnailSize={isMobile ? 110 : 120}
+      />
+    </section>
+  );
+};

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -4,7 +4,7 @@ import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 
 import createCache from '@emotion/cache';
-import { css, CacheProvider } from '@emotion/core';
+import { CacheProvider } from '@emotion/core';
 
 import { store } from 'app/store';
 import { Actions } from 'app/services/user';
@@ -16,6 +16,7 @@ import { ConnectedEnvBadge } from 'app/components/EnvBadge';
 import { initializeScrollEnd } from 'app/utils/onWindowScrollEnd';
 import { setInitializeInAppEvent } from 'app/utils/inAppMessageEvents';
 import { selectIsInApp } from './services/environment/selectors';
+import ResponsiveManager from './ResponsiveManager';
 
 // Show browser input focused outline when tab key is pressed
 setTabKeyFocus();
@@ -52,6 +53,7 @@ class App extends React.Component {
             },
           ]}
         />
+        <ResponsiveManager />
         <CacheProvider value={styleCache}>
           <ConnectedEnvBadge />
           <ConnectedRoutes />

--- a/src/app/services/commonUI/index.ts
+++ b/src/app/services/commonUI/index.ts
@@ -23,6 +23,9 @@ export const Actions = {
   updateGNBTabExpose: createAction<{
     isGnbTab: boolean;
   }>('updateGNBTabExpose'),
+  updateIsMobile: createAction<{
+    isMobile: boolean;
+  }>('updateIsMobile'),
 };
 
 export const GNB_DEFAULT_COLOR: RGB = {
@@ -65,6 +68,7 @@ export interface CommonUIState {
   gnbTransparentType: GNBTransparentType;
   isGnbTab: boolean;
   footerTheme: FooterTheme;
+  isMobile: boolean;
 }
 
 export const INITIAL_STATE: CommonUIState = {
@@ -74,6 +78,7 @@ export const INITIAL_STATE: CommonUIState = {
   gnbTransparentType: GNBTransparentType.default,
   isGnbTab: true,
   footerTheme: FooterTheme.default,
+  isMobile: true,
 };
 
 export const commonUIReducer = createReducer<typeof INITIAL_STATE>({}, INITIAL_STATE);
@@ -112,4 +117,9 @@ commonUIReducer.on(Actions.updateFooterTheme, (state, action) => ({
 commonUIReducer.on(Actions.updateGNBTabExpose, (state, action) => ({
   ...state,
   isGnbTab: action.isGnbTab,
+}));
+
+commonUIReducer.on(Actions.updateIsMobile, (state, action) => ({
+  ...state,
+  isMobile: action.isMobile,
 }));

--- a/src/app/services/commonUI/selectors.ts
+++ b/src/app/services/commonUI/selectors.ts
@@ -50,3 +50,5 @@ export const getGNBType = createSelector(
       ? GNBColorLevel.TRANSPARENT
       : gnbColorLevel,
 );
+
+export const getIsMobile = (state: RidiSelectState): boolean => state.commonUI.isMobile;


### PR DESCRIPTION
[도서 리스트 레이아웃 깨짐](https://app.asana.com/0/8314863450537/1165224008587587) 대응
react-responsive 가 간헐적으로 동작하지 않아 레이아웃이 깨지는 현상 발생
각 도서 리스트 섹션마다 개별적으로 `MeadiaQuery` 를 사용중인데 업데이트가 빈번하여 발생하는 것이 아닐까 예상, 사용처 거의 대부분이 `max-width: 834px` 로 isMobile 을 구분하는 용도로 사용하고 있어서 이를 store 에서 관리하도록 수정.
나머지 사용처들은 차차 교체 해나갈 예정
