### PR TITLE
requestArticles 에서 query string encode 하지 않도록 수정.

### DIFF
--- a/src/app/services/articleList/requests.ts
+++ b/src/app/services/articleList/requests.ts
@@ -33,11 +33,14 @@ export const requestArticles = (
     size?: number;
   },
 ): Promise<ArticleListResponse> => {
-  const additionalQueryString = qs.stringify({
-    page: etcParams?.page || 1,
-    size: etcParams?.size || COUNT_PER_PAGE,
-    ids: etcParams?.articleIds || undefined,
-  });
+  const additionalQueryString = qs.stringify(
+    {
+      page: etcParams?.page || 1,
+      size: etcParams?.size || COUNT_PER_PAGE,
+      ids: etcParams?.articleIds?.join(',') || undefined,
+    },
+    { encode: false },
+  );
   return request({
     url: `/article/articles${buildArticleRequestQueriesToString(
       requestQueries,

--- a/src/app/services/searchResult/sagas.ts
+++ b/src/app/services/searchResult/sagas.ts
@@ -59,13 +59,15 @@ export function* queryKeyword({ payload }: ReturnType<typeof Actions.queryKeywor
       const articles: Article[] = articlesResponse.results;
       const articlesMap = keyBy(articles, 'id');
       yield put(ArticleActions.updateArticles({ articles }));
-      const searchResultArticles: SearchResultArticle[] = response.articles.map(article => {
-        const searchResultArticle: SearchResultArticle = articlesMap[
-          article.id
-        ] as SearchResultArticle;
-        searchResultArticle.highlight = article.highlight;
-        return searchResultArticle;
-      });
+      const searchResultArticles: SearchResultArticle[] = response.articles
+        .filter(article => articlesMap[article.id])
+        .map(article => {
+          const searchResultArticle: SearchResultArticle = articlesMap[
+            article.id
+          ] as SearchResultArticle;
+          searchResultArticle.highlight = article.highlight;
+          return searchResultArticle;
+        });
       searchResultResponse.articles = searchResultArticles;
     }
     yield put(Actions.queryKeywordSuccess({ keyword, page, type, response: searchResultResponse }));


### PR DESCRIPTION
아티클 요청 결과에서 아티클 결과에는 있지만 아티클 응답에는 데이터가 없는경우 필터링 하여 검색 결과에는 데이터가 있는데 역으로 셀렉트 백엔드에 없는 아티클의 케이스 처리하여 데이터가 싱크가 맞지 않아도 렌더링에 이슈 없게 수정 했습니다.