### PR TITLE
iOS 인앱에서 서점링크 허용

### DIFF
--- a/src/app/utils/inAppMessageEvents.ts
+++ b/src/app/utils/inAppMessageEvents.ts
@@ -17,7 +17,6 @@ export const setInitializeInAppEvent = () => {
         name: 'setBlacklistOfOutlink',
         args: [
           [
-            '//ridibooks.com',
             '//library.ridibooks.com',
             '//outstanding.kr/premium-membership',
             '//outstanding.kr/register',


### PR DESCRIPTION
[관련 태스크](https://app.asana.com/0/8314863450537/1159772848035617)
- 앱에 post-robot 으로 블랙리스트 전달하는데 그중 `//ridibooks.com` 제외 처리