### PR TITLE
홈 섹션 아이콘 레이아웃 및 상세페이지 헤더 영역 색상이슈 대응

### DIFF
--- a/src/app/components/HomeSectionHeader/styles.ts
+++ b/src/app/components/HomeSectionHeader/styles.ts
@@ -34,6 +34,7 @@ export const sectionTitleArrowIcon = css`
   height: 10px;
   transition: fill 0.2s;
   fill: ${Colors.slategray_60};
+  vertical-align: top;
 
   @media ${Media.PC} {
     position: relative;

--- a/src/css/book_detail/index.css
+++ b/src/css/book_detail/index.css
@@ -11,7 +11,7 @@
 
   @media (--pc-screen) {
     text-align: left;
-    @nest :not(.PageBookDetail_Header-bright) & {
+    &:not(.PageBookDetail_Header-bright):not(.PageBookDetail_Header-default) {
       color: #fff;
       fill: #fff;
     }
@@ -256,7 +256,7 @@
     content: '';
     opacity: 0.3;
     @media (--pc-screen) {
-      @nest :not(.PageBookDetail_Header-bright) & {
+      @nest .PageBookDetail_Header-dark & {
         background-color: #fff;
       }
     }
@@ -275,7 +275,7 @@
     content: '';
     opacity: 0.3;
     @media (--pc-screen) {
-      @nest :not(.PageBookDetail_Header-bright) & {
+      @nest .PageBookDetail_Header-dark & {
         background-color: #fff;
       }
     }
@@ -316,7 +316,7 @@
   opacity: 0.8;
   fill: #000;
   @media (--pc-screen) {
-    @nest :not(.PageBookDetail_Header-bright) & {
+    @nest .PageBookDetail_Header-dark & {
       fill: #fff;
     }
   }


### PR DESCRIPTION
- 홈 섹션들의 타이틀 링크 아이콘의 수직정렬 틀어짐 수정
- 도서 상세페이지 헤더의 색상이 default 인 경우 색상 분기처리 누락된 것 추가
  - 잘못된 셀렉터 수정
  - 잘못된 조건 수정