### PR TITLE
도서 상세페이지 배경색 IE 이슈 대응

### DIFF
--- a/src/app/services/commonUI/index.ts
+++ b/src/app/services/commonUI/index.ts
@@ -95,7 +95,11 @@ commonUIReducer.on(Actions.updateGNBColor, (state, action) => {
   const blueCalc = color.b * 0.114;
   return {
     ...state,
-    gnbColor: color,
+    gnbColor: {
+      r: Math.round(color.r),
+      g: Math.round(color.g),
+      b: Math.round(color.b),
+    },
     gnbColorLevel: isDefaultColor(color)
       ? GNBColorLevel.DEFAULT
       : color.r === GNB_DEFAULT_COLOR.r && redCalc + greenCalc + blueCalc > 186


### PR DESCRIPTION
- IE에서 CSS rgba 에 실수 값이 들어가는 경우 배경색 지정 안되는 이슈 대응