### PR TITLE
레이아웃 이슈 대응 및 스테이징 배포 브랜치 규칙 추가

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ workflows:
             branches:
               only:
                 - master
+                - staging
           dev: true
       - deploy:
           name: deploy-dev

--- a/src/app/components/InlineHorizontalBookList.tsx
+++ b/src/app/components/InlineHorizontalBookList.tsx
@@ -83,7 +83,7 @@ const SC = {
         margin-left: 0;
       }
       &:nth-of-type(6n + 1) {
-        margin-left: ${(props: StyledBookProps) => (props.inlineDisabled ? '16px' : 0)};
+        margin-left: 0;
       }
       &:nth-of-type(n + 7) {
         ${(props: StyledBookProps) =>

--- a/src/app/placeholder/BookListPlaceholder.tsx
+++ b/src/app/placeholder/BookListPlaceholder.tsx
@@ -46,11 +46,11 @@ const SkeletonSC = {
   `,
   SpotlightBook: styled.li`
     width: 140px;
-    @media ${Media.MOBILE} {
-      &:first-of-type {
-        padding-left: 0;
-      }
-      &:last-of-type {
+    &:first-of-type {
+      padding-left: 0;
+    }
+    &:last-of-type {
+      @media ${Media.MOBILE} {
         padding-right: 20px;
       }
     }

--- a/src/app/placeholder/HomeSectionPlaceholder.tsx
+++ b/src/app/placeholder/HomeSectionPlaceholder.tsx
@@ -68,9 +68,6 @@ const Skeletons = {
       padding-top: 30px;
       overflow: hidden;
     }
-    @media ${SpotlightMedia.SLIDER} {
-      text-align: center;
-    }
   `,
   SpotlightTitle: styled.div`
     ${skeleton}


### PR DESCRIPTION
레이아웃 이슈 대응
- 도서 상세의 도서리스트 토글 섹션 레이아웃이 깨지는 문제 대응
- 관련 태스크
  - https://app.asana.com/0/1182108001576329/1182523191604873

스테이징 테스트 위한 브랜치 규칙 추가 
- 문제
  - PR전 디자인 QA를 위해 CI 스테이징 배포 규칙중 브랜치 규칙을 매번 임시로 수정해서 확인하고 QA 마치면 다시 원복하는 과정이 반복
- 대응
  - 스테이징 테스트를 위한 배포 규칙에 `staging` 이라는 브랜치 추가 