### PR TITLE
Change a slack notification channel to #deploy from #select-deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
     parameters:
       channel:
         type: string
-        default: deploy-select
+        default: deploy
       prefix:
         type: string
         default: ''


### PR DESCRIPTION
배포 알람을 하나의 채널에 관리하기 위해서 circle CI의 배포 알림을 #deploy  채널로 오도록 으로 변경하도록 수정하였습니다. 

개발 환경 배포 알람에 대해서는 정해진 게 없어 만약 변경될 시 추가로 mr 올리겠습니다. :bow: 